### PR TITLE
periodically updates of current playing time using setTimeout instead of setInterval

### DIFF
--- a/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/player/WebViewYouTubePlayer.java
+++ b/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/player/WebViewYouTubePlayer.java
@@ -143,6 +143,15 @@ class WebViewYouTubePlayer extends WebView implements YouTubePlayer, YouTubePlay
             }
         });
     }
+    @Override
+    public void sendCurrentSeconds() {
+        mainThreadHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                loadUrl("javascript:onCurrentSeconds()");
+            }
+        });
+    }
 
     @Override
     @PlayerConstants.PlayerState.State

--- a/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/player/YouTubePlayer.java
+++ b/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/player/YouTubePlayer.java
@@ -32,6 +32,11 @@ public interface YouTubePlayer {
      * @param time The absolute time in seconds to seek to
      */
     void seekTo(final int time);
+    /**
+     * trigger the {@link YouTubePlayerListener#onCurrentSecond(float)}  callback
+     * with the video current playing time in second
+     */
+    void sendCurrentSeconds();
 
     @PlayerConstants.PlayerState.State
     int getCurrentState();

--- a/YouTubePlayer/src/main/res/raw/youtube_player.html
+++ b/YouTubePlayer/src/main/res/raw/youtube_player.html
@@ -67,9 +67,6 @@
     	}
 
     	function sendPlayerStateChange(playerState) {
-            var timerTaskId;
-            clearTimeout(timerTaskId);
-
             switch (playerState) {
             	case YT.PlayerState.UNSTARTED:
                     sendStateChange(UNSTARTED);
@@ -81,9 +78,7 @@
 
                 case YT.PlayerState.PLAYING:
                     sendStateChange(PLAYING);
-                    timerTaskId = setInterval(function() {
-                      YouTubePlayerBridge.sendVideoCurrentTime( player.getCurrentTime() )
-                    }, 100 );
+                    updateCurrentSecond();
                     sendVideoData(player);
                     return;
 
@@ -98,6 +93,16 @@
                 case YT.PlayerState.CUED:
                     sendStateChange(CUED);
                     return;
+            }
+            function updateCurrentSecond() {
+                onCurrentSeconds();
+        	    if(playerState==PLAYING){
+        	       setTimeout(updateCurrentSecond, 100);
+        	    }
+            }
+            //updates the current time in java code
+            function onCurrentSeconds() {
+        	    YouTubePlayerBridge.sendVideoCurrentTime(player.getCurrentTime());
             }
 
             function sendVideoData(player) {


### PR DESCRIPTION
Hi thanks a lot for this library!
While using it, I found that in some cases the timerTask was not correctly removed. I was getting a deluge of updates of the current playing time and the app performance was suffering. So I what I did? I substituted
it with setTimeout, and I have also added a method sendCurrentSeconds() to YouTubePlayer interface to ask the player the current time, even when player is paused. 