### PR TITLE
feat: Introduce support for Live-VOD mode for live streams

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/ui/DefaultPlayerUIController.java
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/ui/DefaultPlayerUIController.java
@@ -71,6 +71,10 @@ public class DefaultPlayerUIController implements PlayerUIController, YouTubePla
     private boolean showPlayPauseButton = true;
     private boolean showBufferingProgress = true;
 
+    private boolean isLive = false;
+    private boolean isLiveVOD = false;
+    private float videoDurationValue = 0;
+
     public DefaultPlayerUIController(@NonNull YouTubePlayerView youTubePlayerView, @NonNull YouTubePlayer youTubePlayer) {
         this.youTubePlayerView = youTubePlayerView;
         this.youTubePlayer = youTubePlayer;
@@ -108,6 +112,7 @@ public class DefaultPlayerUIController implements PlayerUIController, YouTubePla
         playPauseButton.setOnClickListener(this);
         menuButton.setOnClickListener(this);
         fullScreenButton.setOnClickListener(this);
+        liveVideoIndicator.setOnClickListener(this);
     }
 
     @Override
@@ -139,18 +144,39 @@ public class DefaultPlayerUIController implements PlayerUIController, YouTubePla
 
     @Override
     public void enableLiveVideoUI(boolean enable) {
+        isLive = enable;
+        enableLiveVODUI(false);
         if(enable) {
             videoDuration.setVisibility(View.INVISIBLE);
-            seekBar.setVisibility(View.INVISIBLE);
             videoCurrentTime.setVisibility(View.INVISIBLE);
 
             liveVideoIndicator.setVisibility(View.VISIBLE);
+            liveVideoIndicator.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_live_dot_red,0,0,0);
+            liveVideoIndicator.setCompoundDrawablePadding((int) youTubePlayerView.getContext().getResources().getDimension(R.dimen._8dp));
         } else {
             videoDuration.setVisibility(View.VISIBLE);
             seekBar.setVisibility(View.VISIBLE);
             videoCurrentTime.setVisibility(View.VISIBLE);
 
             liveVideoIndicator.setVisibility(View.GONE);
+        }
+    }
+
+    /**
+     * This is the case when user manually changes the seekbar position during a live stream.
+     * In this case, the player switches to a Live-VOD (Video-On-Demand) mode.
+     * UI changes are made on 1) Live video indicator tag, 2) Seekbar behaviour.
+     * This is in sync with the standard behaviour inside youtube app.
+     *
+     */
+    private void enableLiveVODUI(boolean enable) {
+        isLiveVOD = enable;
+        if (enable) {
+            liveVideoIndicator.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_live_dot_white,0,0,0);
+            videoCurrentTime.setVisibility(View.VISIBLE);
+        } else {
+            liveVideoIndicator.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_live_dot_red,0,0,0);
+            videoCurrentTime.setVisibility(View.INVISIBLE);
         }
     }
 
@@ -266,6 +292,20 @@ public class DefaultPlayerUIController implements PlayerUIController, YouTubePla
             onFullScreenButtonPressed();
         else if(view == menuButton)
             onMenuButtonPressed();
+        else if (view == liveVideoIndicator)
+            onLiveVideoIndicatorPressed();
+    }
+
+    /**
+     * During a live session when user switches to VOD mode by moving the seekbar,
+     * this allows the user to get back to the live mode instantly.
+     * This is in sync with the default youtube app behaviour
+     */
+    private void onLiveVideoIndicatorPressed() {
+        enableLiveVideoUI(true);
+        if (videoDurationValue != 0)
+            youTubePlayer.seekTo(videoDurationValue);
+        seekBar.setProgress(Math.round(videoDurationValue));
     }
 
     private void onMenuButtonPressed() {
@@ -442,6 +482,7 @@ public class DefaultPlayerUIController implements PlayerUIController, YouTubePla
 
     @Override
     public void onVideoDuration(float duration) {
+        videoDurationValue = duration;
         videoDuration.setText(Utils.formatTime(duration));
         seekBar.setMax((int) duration);
     }
@@ -479,13 +520,45 @@ public class DefaultPlayerUIController implements PlayerUIController, YouTubePla
 
     @Override
     public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
-        videoCurrentTime.setText(Utils.formatTime(i));
+        if (isLive) {
+            handleProgressChangedDuringLive(seekBar,i);
+        } else {
+            videoCurrentTime.setText(Utils.formatTime(i));
+        }
+    }
+
+    /**
+     * This handles the case when progress changes during Live stream.
+     * There are two scenarios being handled here a) Live b) Live-VOD.
+     * a) In case of Live, we maintain the seekbar to the value same same as duration.
+     * b) In case of Live-VOD, the current time is updated to show the negative value of
+     * current time, which lets user know how far they're behind the Live stream.
+     *
+     * Both a) & b) are in sync with default youtube app behaviour.
+     *
+     */
+    private void handleProgressChangedDuringLive(SeekBar seekBar, int i) {
+        // Can't do much without video duration value
+        if (videoDurationValue == 0)
+            return;
+
+        if (i == videoDurationValue) {
+            enableLiveVideoUI(true);
+            return;
+        }
+        if (isLiveVOD) {
+            String currentTime = "-" + Utils.formatTime(videoDurationValue - i);
+            videoCurrentTime.setText(currentTime);
+        } else {
+            seekBar.setProgress(Math.round(videoDurationValue));
+        }
     }
 
     @Override
     public void onStartTrackingTouch(SeekBar seekBar) {
-        seekBarTouchStarted = true;
-    }
+        if (isLive)
+            enableLiveVODUI(true);
+        seekBarTouchStarted = true;    }
 
     @Override
     public void onStopTrackingTouch(SeekBar seekBar) {

--- a/core/src/main/res/drawable/ic_live_dot_red.xml
+++ b/core/src/main/res/drawable/ic_live_dot_red.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#F44336" />
+    <size
+        android:width="8dp"
+        android:height="8dp" />
+</shape>

--- a/core/src/main/res/drawable/ic_live_dot_white.xml
+++ b/core/src/main/res/drawable/ic_live_dot_white.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FFFFFF" />
+    <size
+        android:width="8dp"
+        android:height="8dp" />
+</shape>


### PR DESCRIPTION
The changes included are :

- Introduced Live-VOD (Video on Demand) mode similar which is enabled when user moves the seekbar during live stream.
- Live stream indicator tag is made clickable and now has the same functionality as that of native app wherein it'll restore the live state.
- Seekbar is always visible now and during Live stream, it's progress position value will be that of the video duration.
