### PR TITLE
Hide title, watch later, share and YouTube watermark

### DIFF
--- a/core/src/main/res/raw/youtube_player.html
+++ b/core/src/main/res/raw/youtube_player.html
@@ -45,7 +45,11 @@
     			width: '100%',
     			
                 events: {
-    				onReady: function(event) { YouTubePlayerBridge.sendReady() },
+    				onReady: function(event) {
+    				    document.querySelector("#youTubePlayerDOM").contentDocument.querySelector('.ytp-chrome-top').style.display = "none"
+    				    document.querySelector("#youTubePlayerDOM").contentDocument.querySelector('.ytp-icon-watermark').style.display = "none"
+    				    YouTubePlayerBridge.sendReady()
+    				},
     				onStateChange: function(event) { sendPlayerStateChange(event.data) },
     				onPlaybackQualityChange: function(event) { YouTubePlayerBridge.sendPlaybackQualityChange(event.data) },
     				onPlaybackRateChange: function(event) { YouTubePlayerBridge.sendPlaybackRateChange(event.data) },

--- a/core/src/main/res/raw/youtube_player.html
+++ b/core/src/main/res/raw/youtube_player.html
@@ -46,8 +46,10 @@
     			
                 events: {
     				onReady: function(event) {
-    				    document.querySelector("#youTubePlayerDOM").contentDocument.querySelector('.ytp-chrome-top').style.display = "none"
-    				    document.querySelector("#youTubePlayerDOM").contentDocument.querySelector('.ytp-icon-watermark').style.display = "none"
+    				    try {
+    				        document.querySelector("#youTubePlayerDOM").contentDocument.querySelector('.ytp-chrome-top').style.display = "none"
+    				        document.querySelector("#youTubePlayerDOM").contentDocument.querySelector('.ytp-icon-watermark').style.display = "none"
+    				    } catch(err) {}
     				    YouTubePlayerBridge.sendReady()
     				},
     				onStateChange: function(event) { sendPlayerStateChange(event.data) },


### PR DESCRIPTION
This is a fix for hiding the unwanted top bar buttons (watch later, share) and title. This also removes lower right YouTube watermark. In this way you have a clean webview.