### PR TITLE
Fix issue with stopping playback

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.util.AttributeSet
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -61,7 +60,7 @@ internal class LegacyYouTubePlayerView(context: Context, attrs: AttributeSet? = 
         // stop playing if the user loads a video but then leaves the app before the video starts playing.
         youTubePlayer.addListener(object : AbstractYouTubePlayerListener() {
             override fun onStateChange(youTubePlayer: YouTubePlayer, state: PlayerConstants.PlayerState) {
-                if(state == PlayerConstants.PlayerState.PLAYING && !canPlay)
+                if(state == PlayerConstants.PlayerState.PLAYING && !isEligibleForPlayback())
                     youTubePlayer.pause()
             }
         })
@@ -196,6 +195,15 @@ internal class LegacyYouTubePlayerView(context: Context, attrs: AttributeSet? = 
         youTubePlayer.pause()
         playbackResumer.onLifecycleStop()
         canPlay = false
+    }
+
+    /**
+     * Checks whether the player is in an eligible for playback in
+     * respect of the {@link WebViewYouTubePlayer#isBackgroundPlaybackEnabled}
+     * property.
+     */
+    internal fun isEligibleForPlayback(): Boolean {
+        return canPlay || youTubePlayer.isBackgroundPlaybackEnabled
     }
 
     /**

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
@@ -198,7 +198,7 @@ internal class LegacyYouTubePlayerView(context: Context, attrs: AttributeSet? = 
     }
 
     /**
-     * Checks whether the player is in an eligible for playback in
+     * Checks whether the player is in an eligible state for playback in
      * respect of the {@link WebViewYouTubePlayer#isBackgroundPlaybackEnabled}
      * property.
      */


### PR DESCRIPTION
When having enableBackgroundPlayback enabled the player stops sometimes when the activity gets into the background. Basically, if background playback is enabled we don't need to mind whether the activity is in fore- or background. This is a fix for it.

I currently can't compile the library on my own, so I haven't tested the changes. I assume it should be fine this way. This issue was raised since fix of issue #326 