### PR TITLE
Add mute / unMute functions

### DIFF
--- a/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/ChromecastYouTubePlayer.kt
+++ b/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/ChromecastYouTubePlayer.kt
@@ -66,6 +66,21 @@ class ChromecastYouTubePlayer internal constructor(private val chromecastCommuni
 
         chromecastCommunicationChannel.sendMessage(message)
     }
+    override fun mute() {
+        val message = JSONUtils.buildFlatJson(
+                "command" to ChromecastCommunicationConstants.MUTE
+        )
+
+        chromecastCommunicationChannel.sendMessage(message)
+    }
+
+    override fun unMute() {
+        val message = JSONUtils.buildFlatJson(
+                "command" to ChromecastCommunicationConstants.UNMUTE
+        )
+
+        chromecastCommunicationChannel.sendMessage(message)
+    }
 
     override fun setVolume(volumePercent: Int) {
         val message = JSONUtils.buildFlatJson(

--- a/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/io/youtube/ChromecastCommunicationConstants.kt
+++ b/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/io/youtube/ChromecastCommunicationConstants.kt
@@ -27,6 +27,8 @@ internal object ChromecastCommunicationConstants {
     const val PAUSE = "PAUSE"
     const val SET_VOLUME = "SET_VOLUME"
     const val SEEK_TO = "SEEK_TO"
+    const val MUTE = "MUTE"
+    const val UNMUTE = "UNMUTE"
 
     fun asJson() = JSONUtils.buildFlatJson(
             IFRAME_API_READY to IFRAME_API_READY,
@@ -45,6 +47,8 @@ internal object ChromecastCommunicationConstants {
             PLAY to PLAY,
             PAUSE to PAUSE,
             SET_VOLUME to SET_VOLUME,
-            SEEK_TO to SEEK_TO
+            SEEK_TO to SEEK_TO,
+            MUTE to MUTE,
+            UNMUTE to UNMUTE
     )
 }

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayer.kt
@@ -23,6 +23,9 @@ interface YouTubePlayer {
     fun play()
     fun pause()
 
+    fun mute()
+    fun unMute()
+
     /**
      * @param volumePercent Integer between 0 and 100
      */

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
@@ -56,6 +56,14 @@ internal class WebViewYouTubePlayer constructor(context: Context, attrs: Attribu
         mainThreadHandler.post { loadUrl("javascript:pauseVideo()") }
     }
 
+    override fun mute() {
+        mainThreadHandler.post { loadUrl("javascript:mute()") }
+    }
+
+    override fun unMute() {
+        mainThreadHandler.post { loadUrl("javascript:unMute()") }
+    }
+
     override fun setVolume(volumePercent: Int) {
         if (volumePercent < 0 || volumePercent > 100)
             throw IllegalArgumentException("Volume must be between 0 and 100")

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -132,6 +132,14 @@
             YouTubePlayerBridge.sendVideoId(videoId);
         }
 
+        function mute() {
+            player.mute();
+        }
+
+        function unMute() {
+            player.unMute();
+        }
+
         function setVolume(volumePercent) {
             player.setVolume(volumePercent);
         }


### PR DESCRIPTION
Exposes the mute/unMute functions from the youtube player

This makes it possible to play a muted video, with the user having the option to unmute it by using the web ui. This wasn't possible with only `setVolume` available.

Fixes #445

It seems this functionality was already half-implemented for the chromecast sender, see https://github.com/pierfrancescosoffritti/android-youtube-player/blob/0fe4f016016eeb02398414f996cf5207bd277d1b/chromecast-receiver/js/io/SenderMessagesDispatcher.js#L25-L28