### PR TITLE
Fix webview in 5. ( lollipop) crash 

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewLollipop.java
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewLollipop.java
@@ -1,0 +1,40 @@
+package com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.webkit.WebView;
+
+import androidx.annotation.RequiresApi;
+
+public class WebViewLollipop extends WebView {
+    public WebViewLollipop(Context context) {
+        super(getFixedContext(context));
+    }
+
+    public WebViewLollipop(Context context, AttributeSet attrs) {
+        super(getFixedContext(context), attrs);
+    }
+
+    public WebViewLollipop(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(getFixedContext(context), attrs, defStyleAttr);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public WebViewLollipop(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(getFixedContext(context), attrs, defStyleAttr, defStyleRes);
+    }
+
+    public WebViewLollipop(Context context, AttributeSet attrs, int defStyleAttr, boolean privateBrowsing) {
+        super(getFixedContext(context), attrs, defStyleAttr, privateBrowsing);
+    }
+
+    public static Context getFixedContext(Context context) {
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP || Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP_MR1) {
+            return context.createConfigurationContext(new Configuration());
+        } else {
+            return context;
+        }
+    }
+}

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
@@ -22,7 +22,7 @@ import java.util.*
  * WebView implementation of [YouTubePlayer]. The player runs inside the WebView, using the IFrame Player API.
  */
 internal class WebViewYouTubePlayer constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
-    : WebView(context, attrs, defStyleAttr), YouTubePlayer, YouTubePlayerBridge.YouTubePlayerBridgeCallbacks {
+    : WebViewLollipop(context, attrs, defStyleAttr), YouTubePlayer, YouTubePlayerBridge.YouTubePlayerBridgeCallbacks {
 
     private lateinit var youTubePlayerInitListener: (YouTubePlayer) -> Unit
 


### PR DESCRIPTION
-Fix WebViewYouTubePlayer crash on Android 5 
(https://stackoverflow.com/questions/41025200/android-view-inflateexception-error-inflating-class-android-webkit-webview/41721789#41721789).
- I also tryed to downgrade appcompat version but it still not work on my 5. device.and this solution work well for all.