### PR TITLE
Add templates for bugs, features and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,103 @@
+---
+name: Bug report
+about: Use this template for reporting bugs
+labels: bug
+---
+
+<!-- 
+READ CAREFULLY:
+This is a template for reporting a bug.
+
+First things first: check if there is already an issue reporting the same bug where you might 
+only provide further information instead of starting a new issue. 
+
+If that is not the case, here are some tips for filling out the following template:
+- Hints are not shown in the issue as long as they are commented out
+- Comments that are not visible start with `\<!--` and end with `--\>`
+- It is recommended to follow the template as much as possible
+--> 
+
+# Bug Report
+
+### Description of the Bug
+<!-- Describe here the bug in detail -->
+
+
+### Environment details
+<!-- One of the following version information is usually enough -->
+Android Version: <!-- e.g. Android 8.1, Android 10 -->
+API Version: <!-- e.g. 27, 29 -->
+
+Tested devices:
+<!-- Provide here a list of devices the bug occur (recommended with API or Android version), e.g. 
+- Pixel 2 API 27
+- Samsung Galaxy S8 API 29
+-->
+
+
+Youtube Player Library Version: <!-- e.g. 10.0.5 or 0.23 (for chromecast) -->
+
+### Steps to reproduce the bug
+---
+name: Bug report
+about: Use this template for reporting bugs
+labels: bug
+---
+
+<!-- 
+READ CAREFULLY:
+This is a template for reporting a bug.
+
+First things first: check if there is already an issue reporting the same bug where you might 
+only provide further information instead of starting a new issue. 
+
+If that is not the case, here are some tips for filling out the following template:
+- Hints are not shown in the issue as long as they are commented out
+- Comments that are not visible start with `\<!--` and end with `--\>`
+- It is recommended to follow the template as much as possible
+--> 
+
+# Bug Report
+
+### Description of the Bug
+<!-- Describe here the bug in detail -->
+
+
+### Environment details
+<!-- One of the following version information is usually enough -->
+Android Version: <!-- e.g. Android 8.1, Android 10 -->
+API Version: <!-- e.g. 27, 29 -->
+
+Tested devices:
+<!-- Provide here a list of devices the bug occur (recommended with API or Android version), e.g. 
+- Pixel 2 API 27
+- Samsung Galaxy S8 API 29
+-->
+
+
+Youtube Player Library Version: <!-- e.g. 10.0.5 or 0.23 (for chromecast) -->
+
+### Steps to reproduce the bug
+<!-- Write here the way to reproduce the bug. E.g.
+1. Create an activity and a layout as provided below
+2. Start the application on the target device
+3. Tap on the video player
+4. See player not playing
+5. See errors in stacktrace (provided below)
+-->
+
+
+### Expected behavior
+<!-- Write here what you were expecting from the app / the player -->
+
+
+### Actual behavior
+<!-- Write here how the app / the player actually behaves -->
+
+
+### Additional information
+<!-- Provide here further information that might help understand the issue or reproduce the bug, e.g. 
+- standalone code snippets of implementation that can copy-pasted and work without any missing classes
+- screenshot(s) of visualising the bug
+- error logs
+- any useful background infromation

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Use this template to request a new feature / an enhancement
+labels: enhancement
+---
+
+<!-- 
+This is a template for requesting new features / enhancements.
+
+There is actually no special format required, but here are some
+hints how you could describe or help us better understand your
+idea.
+-->
+
+# Feature Request
+
+### Describe your idea
+<!-- 
+Describe here your idea. Try to write your idea in a short 
+and long version, so someone reading your short version understands
+what you are asking for and a contributor knows with the long 
+version what exactly you want to have at the end. 
+-->
+
+
+### Expected behavior and realization
+<!-- Add here the expected behavior with optional screenshots, 
+sketches or pseudo code that helps to understand how it could be
+roughly implemented. -->
+

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -1,0 +1,29 @@
+---
+name: Question / Problem
+about: Use this template for asking questions or describe problems
+labels: question
+---
+
+<!-- 
+This template is for asking questions or describing problems to solve
+together with the developer(s) or contributors of the library.
+
+Try to provide enough information to let the others understand what you try to achieve and where the problem is.
+
+The following form is just a recommendation, you can of course use your
+own titles (if any) to ask your question.
+-->
+
+# Question / Problem
+
+### Summary
+<!-- 
+Summarize your problem here. Include details about your goal, 
+describe expected and actual results, include any error messages, provide the requirements / restrictions you have, etc.
+-->
+
+### What I've tried
+<!-- 
+Describe here what you have tried. Show some code snippets with 
+output screenshots or logs. 
+-->


### PR DESCRIPTION

### About the changes
- Provide 3 different templates (bug report, features request and question / problem)
- All templates include some comments that help the reporter fill out the predefined fields

### What this PR improves
This PR aims to improve the bug reporting that is completely formless at the moment of writing 
and every issue reporting a bug misses important information for reproduction. The PR also provides
some templates for questions and feature requests that can also be ignored but help people write down 
their idea or question and get faster and easier a response.