### PR TITLE
WIP: Add playback rate implementation

### DIFF
--- a/chromecast-receiver/js/YouTubePlayer.js
+++ b/chromecast-receiver/js/YouTubePlayer.js
@@ -95,7 +95,7 @@ function YouTubePlayer(communicationConstants, communicationChannel) {
     }
 
     // JAVA to WEB functions
-    function seekTo(startSeconds) {        	
+    function seekTo(startSeconds) {
         player.seekTo(startSeconds, true)
     }
 
@@ -133,11 +133,15 @@ function YouTubePlayer(communicationConstants, communicationChannel) {
         player.setVolume(volumePercent)
     }
 
+    function setPlaybackRate(suggestedRate) {
+        player.setPlaybackRate(suggestedRate)
+    }
+
     function getActions() {
         return actions
     }
 
-    const actions = { seekTo, pauseVideo, playVideo, loadVideo, cueVideo, mute, unMute, setVolume }
+    const actions = { seekTo, pauseVideo, playVideo, loadVideo, cueVideo, mute, unMute, setVolume, setPlaybackRate }
     
     return {
         initialize,

--- a/chromecast-receiver/js/io/SenderMessagesDispatcher.js
+++ b/chromecast-receiver/js/io/SenderMessagesDispatcher.js
@@ -28,6 +28,8 @@ function SenderMessagesDispatcher(communicationConstants, callbacks) {
             callbacks.unMute()
         else if(message.data.command === communicationConstants.SET_VOLUME)
             callbacks.setVolume(Number(message.data.volumePercent))
+        else if(message.data.command === communicationConstants.SET_PLAYBACK_RATE)
+            callbacks.setPlaybackRate(Number(message.data.suggestedRate))
         else if(message.data.command === communicationConstants.SEEK_TO)
             callbacks.seekTo(Number(message.data.time))
     }

--- a/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/ChromecastYouTubePlayer.kt
+++ b/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/ChromecastYouTubePlayer.kt
@@ -100,6 +100,15 @@ class ChromecastYouTubePlayer internal constructor(private val chromecastCommuni
         chromecastCommunicationChannel.sendMessage(message)
     }
 
+    override fun setPlaybackRate(suggestedRate: Float) {
+        val message = JSONUtils.buildFlatJson(
+                "command" to ChromecastCommunicationConstants.SET_PLAYBACK_RATE,
+                "suggestedRate" to suggestedRate.toString()
+        )
+
+        chromecastCommunicationChannel.sendMessage(message)
+    }
+
     override fun addListener(listener: YouTubePlayerListener): Boolean = youTubePlayerListeners.add(listener)
     override fun removeListener(listener: YouTubePlayerListener): Boolean = youTubePlayerListeners.remove(listener)
     override fun getListeners(): MutableCollection<YouTubePlayerListener> = youTubePlayerListeners

--- a/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/io/youtube/ChromecastCommunicationConstants.kt
+++ b/chromecast-sender/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/chromecast/chromecastsender/io/youtube/ChromecastCommunicationConstants.kt
@@ -26,6 +26,7 @@ internal object ChromecastCommunicationConstants {
     const val PLAY = "PLAY"
     const val PAUSE = "PAUSE"
     const val SET_VOLUME = "SET_VOLUME"
+    const val SET_PLAYBACK_RATE = "SET_PLAYBACK_RATE"
     const val SEEK_TO = "SEEK_TO"
     const val MUTE = "MUTE"
     const val UNMUTE = "UNMUTE"
@@ -47,6 +48,7 @@ internal object ChromecastCommunicationConstants {
             PLAY to PLAY,
             PAUSE to PAUSE,
             SET_VOLUME to SET_VOLUME,
+            SET_PLAYBACK_RATE to SET_PLAYBACK_RATE,
             SEEK_TO to SEEK_TO,
             MUTE to MUTE,
             UNMUTE to UNMUTE

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayer.kt
@@ -37,6 +37,24 @@ interface YouTubePlayer {
      */
     fun seekTo(time: Float)
 
+    /**
+     * Sets the suggested playback rate for the video.
+     *
+     * The YouTubePlayer does not guarantee that the playback rate will actually change or change
+     * to the specified value.
+     * If confirmation of the change is required use {@code onPlaybackRateChange}.
+     *
+     * @param suggestedRate Any value between {@code 0.25} and {@code 2.0}. Values below {@code 0.25}
+     *                      and above {@code 2.0} will be automatically increased to {@code 0.25}
+     *                      and decreased to {@code 2.0} accordingly from the YouTube API if the
+     *                      rate get changed. Values that are not divisible by {@code 0.05} might
+     *                      be rounded down (e.g. {@code 0.57} to {@code 0.55}). If the value changes
+     *                      the callback function {@code onPlaybackRateChange} will provide the actual
+     *                      rate that has been applied.
+     * @see YouTubePlayerListener.onPlaybackRateChange
+     */
+    fun setPlaybackRate(suggestedRate: Float)
+
     fun addListener(listener: YouTubePlayerListener): Boolean
     fun removeListener(listener: YouTubePlayerListener): Boolean
 }

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayerBridge.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayerBridge.kt
@@ -33,12 +33,6 @@ class YouTubePlayerBridge(private val youTubePlayerOwner: YouTubePlayerBridgeCal
         private const val QUALITY_HIGH_RES = "highres"
         private const val QUALITY_DEFAULT = "default"
 
-        private const val RATE_0_25 = "0.25"
-        private const val RATE_0_5 = "0.5"
-        private const val RATE_1 = "1"
-        private const val RATE_1_5 = "1.5"
-        private const val RATE_2 = "2"
-
         private const val ERROR_INVALID_PARAMETER_IN_REQUEST = "2"
         private const val ERROR_HTML_5_PLAYER = "5"
         private const val ERROR_VIDEO_NOT_FOUND = "100"
@@ -88,7 +82,13 @@ class YouTubePlayerBridge(private val youTubePlayerOwner: YouTubePlayerBridgeCal
 
     @JavascriptInterface
     fun sendPlaybackRateChange(rate: String) {
-        val playbackRate = parsePlaybackRate(rate)
+        val playbackRate: Float
+        try {
+            playbackRate = rate.toFloat()
+        } catch (e: NumberFormatException) {
+            e.printStackTrace()
+            return
+        }
 
         mainThreadHandler.post {
             for (listener in youTubePlayerOwner.getListeners())
@@ -194,17 +194,6 @@ class YouTubePlayerBridge(private val youTubePlayerOwner: YouTubePlayerBridgeCal
             quality.equals(QUALITY_HIGH_RES, ignoreCase = true) -> PlayerConstants.PlaybackQuality.HIGH_RES
             quality.equals(QUALITY_DEFAULT, ignoreCase = true) -> PlayerConstants.PlaybackQuality.DEFAULT
             else -> PlayerConstants.PlaybackQuality.UNKNOWN
-        }
-    }
-
-    private fun parsePlaybackRate(rate: String): PlayerConstants.PlaybackRate {
-        return when {
-            rate.equals(RATE_0_25, ignoreCase = true) -> PlayerConstants.PlaybackRate.RATE_0_25
-            rate.equals(RATE_0_5, ignoreCase = true) -> PlayerConstants.PlaybackRate.RATE_0_5
-            rate.equals(RATE_1, ignoreCase = true) -> PlayerConstants.PlaybackRate.RATE_1
-            rate.equals(RATE_1_5, ignoreCase = true) -> PlayerConstants.PlaybackRate.RATE_1_5
-            rate.equals(RATE_2, ignoreCase = true) -> PlayerConstants.PlaybackRate.RATE_2
-            else -> PlayerConstants.PlaybackRate.UNKNOWN
         }
     }
 

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/listeners/AbstractYouTubePlayerListener.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/listeners/AbstractYouTubePlayerListener.kt
@@ -10,7 +10,7 @@ abstract class AbstractYouTubePlayerListener : YouTubePlayerListener {
     override fun onReady(youTubePlayer: YouTubePlayer) {}
     override fun onStateChange(youTubePlayer: YouTubePlayer, state: PlayerConstants.PlayerState) {}
     override fun onPlaybackQualityChange(youTubePlayer: YouTubePlayer, playbackQuality: PlayerConstants.PlaybackQuality) {}
-    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: PlayerConstants.PlaybackRate) {}
+    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: Float) {}
     override fun onError(youTubePlayer: YouTubePlayer, error: PlayerConstants.PlayerError) {}
     override fun onApiChange(youTubePlayer: YouTubePlayer) {}
     override fun onCurrentSecond(youTubePlayer: YouTubePlayer, second: Float) {}

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/listeners/YouTubePlayerListener.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/listeners/YouTubePlayerListener.kt
@@ -23,10 +23,10 @@ interface YouTubePlayerListener {
     fun onPlaybackQualityChange(youTubePlayer: YouTubePlayer, playbackQuality: PlayerConstants.PlaybackQuality)
 
     /**
-     * Called every time the speed of the playback changes. Check [PlayerConstants.PlaybackRate] to see all the possible values.
-     * @param playbackRate a state from [PlayerConstants.PlaybackRate]
+     * Called every time the speed of the playback changes. The value range is between 0 and 2.
+     * @param playbackRate the actual playback rate
      */
-    fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: PlayerConstants.PlaybackRate)
+    fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: Float)
 
     /**
      * Called when an error occurs in the player. Check [PlayerConstants.PlayerError] to see all the possible values.

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
@@ -84,6 +84,10 @@ internal class WebViewYouTubePlayer constructor(context: Context, attrs: Attribu
         return Collections.unmodifiableCollection(HashSet(youTubePlayerListeners))
     }
 
+    override fun setPlaybackRate(suggestedRate: Float) {
+        mainThreadHandler.post { loadUrl("javascript:setPlaybackRate($suggestedRate)") }
+    }
+
     override fun addListener(listener: YouTubePlayerListener): Boolean {
         return youTubePlayerListeners.add(listener)
     }

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/DefaultPlayerUiController.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/DefaultPlayerUiController.kt
@@ -290,7 +290,7 @@ internal class DefaultPlayerUiController(private val youTubePlayerView: LegacyYo
 
     override fun onReady(youTubePlayer: YouTubePlayer) {}
     override fun onPlaybackQualityChange(youTubePlayer: YouTubePlayer, playbackQuality: PlayerConstants.PlaybackQuality) {}
-    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: PlayerConstants.PlaybackRate) {}
+    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: Float) {}
     override fun onError(youTubePlayer: YouTubePlayer, error: PlayerConstants.PlayerError) {}
     override fun onApiChange(youTubePlayer: YouTubePlayer) {}
     override fun onCurrentSecond(youTubePlayer: YouTubePlayer, second: Float) {}

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/utils/FadeViewHelper.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/utils/FadeViewHelper.kt
@@ -97,7 +97,7 @@ class FadeViewHelper(val targetView: View): YouTubePlayerListener {
 
     override fun onReady(youTubePlayer: YouTubePlayer) { }
     override fun onPlaybackQualityChange(youTubePlayer: YouTubePlayer, playbackQuality: PlayerConstants.PlaybackQuality) { }
-    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: PlayerConstants.PlaybackRate) { }
+    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: Float) { }
     override fun onError(youTubePlayer: YouTubePlayer, error: PlayerConstants.PlayerError) { }
     override fun onApiChange(youTubePlayer: YouTubePlayer) { }
     override fun onCurrentSecond(youTubePlayer: YouTubePlayer, second: Float) { }

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/views/YouTubePlayerSeekBar.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/views/YouTubePlayerSeekBar.kt
@@ -148,7 +148,7 @@ class YouTubePlayerSeekBar(context: Context, attrs: AttributeSet? = null): Linea
     override fun onVideoId(youTubePlayer: YouTubePlayer, videoId: String) { }
     override fun onApiChange(youTubePlayer: YouTubePlayer) { }
     override fun onPlaybackQualityChange(youTubePlayer: YouTubePlayer, playbackQuality: PlayerConstants.PlaybackQuality) { }
-    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: PlayerConstants.PlaybackRate) { }
+    override fun onPlaybackRateChange(youTubePlayer: YouTubePlayer, playbackRate: Float) { }
     override fun onError(youTubePlayer: YouTubePlayer, error: PlayerConstants.PlayerError) { }
 }
 

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -136,6 +136,11 @@
             player.mute();
         }
 
+        function setPlaybackRate(suggestedRate) {
+            player.setPlaybackRate(suggestedRate);
+            YouTubePlayerBridge.setPlaybackRate(videoId);
+        }
+
         function unMute() {
             player.unMute();
         }


### PR DESCRIPTION
This commit adds playback rate support. It also removes the enum
of playback rates from the constants, since the playback rate can
be any value between `0.25` and `2.0`.

TODO: Check if the chromecast command "SET_PLAYBACK_RATE" is correct and works (I have no idea how to test for chromecast).

Tested on API 30 and works like a charm (except the limitations of the value set by the YouTube API).

Example usage of the new feature: 
```java

@Override
protected void onCreate(Bundle savedInstanceState) {
    super.onCreate(savedInstanceState);
    setContentView(R.layout.activity_simple_example);

    YouTubePlayerView youTubePlayerView = findViewById(R.id.youtube_player_view);

    youTubePlayerView.addYouTubePlayerListener(new AbstractYouTubePlayerListener() {
        @Override
        public void onPlaybackRateChange(YouTubePlayer youTubePlayer, float playbackRate) {
            super.onPlaybackRateChange(youTubePlayer, playbackRate);
            Log.d("PLAYBACK", "Playback changed to:" + playbackRate);
        }
    });

    youTubePlayerView.getYouTubePlayerWhenReady(youTubePlayer -> youTubePlayer.setPlaybackRate(1.5f));

    getLifecycle().addObserver(youTubePlayerView);
}
```

Closes #101.
Closes #645.