### PR TITLE
ConnectivityManger leaks the context on Android 12

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/utils/Utils.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/utils/Utils.kt
@@ -8,7 +8,7 @@ import java.io.InputStreamReader
 
 internal object Utils {
     fun isOnline(context: Context): Boolean {
-        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val connectivityManager = context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val networkInfo = connectivityManager.activeNetworkInfo
         return networkInfo != null && networkInfo.isConnected
     }


### PR DESCRIPTION
the context object getSystemService() is called on is leaked via `ConnectivityManager.sInstance`