### PR TITLE
Update TimeUtilities.kt

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/utils/TimeUtilities.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/utils/TimeUtilities.kt
@@ -10,8 +10,27 @@ object TimeUtilities {
     @SuppressLint("DefaultLocale")
     @JvmStatic
     fun formatTime(timeInSeconds: Float): String {
-        val minutes = (timeInSeconds / 60).toInt()
-        val seconds = (timeInSeconds % 60).toInt()
-        return String.format("%d:%02d", minutes, seconds)
+        var timeString =""
+        
+        var hours = timeInSeconds / 3600
+        var minutes = (timeInSeconds % 3600) / 60
+        var seconds = timeInSeconds % 60
+       
+        
+         //formatting hours minutes and seconds in string
+        if(hours==0L && minutes==0L){
+            timeString = String.format("%d:%02d", minutes, seconds)
+        }else if(hours==0L && minutes<10L){
+            timeString = String.format("%d:%02d", minutes, seconds)
+        }else if(hours==0L && minutes>9L){
+            timeString = String.format("%02d:%02d", minutes, seconds)
+        }else if(hours<10L && hours>0L){
+            timeString = String.format("%d:%02d:%02d", hours, minutes, seconds)
+        }else if(hours>9L){
+            timeString = String.format("%02d:%02d:%02d", hours, minutes, seconds)
+        }
+
+        
+        return timeString
     }
 }


### PR DESCRIPTION
Video playing elapsed time and video total duration was formatted only in minutes and seconds. It can be formatted in hours, minutes and seconds for an hours long videos. 