### PR TITLE
Update DefaultPlayerUiController.kt

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/DefaultPlayerUiController.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/ui/DefaultPlayerUiController.kt
@@ -205,6 +205,12 @@ class DefaultPlayerUiController(private val youTubePlayerView: YouTubePlayerView
         return this
     }
 
+    
+    override fun showProgressBar(show: Boolean): PlayerUiController {
+        progressBar.visibility = if (show) View.VISIBLE else View.GONE
+        return this
+    }
+    
     override fun showBufferingProgress(show: Boolean): PlayerUiController {
         youtubePlayerSeekBar.showBufferingProgress = show
         return this


### PR DESCRIPTION
Adding an implemented method for progress bar . . . . Since a default progress bar cannot be disabled or hidden, a custom progress bar in a controlsContainer view can be hidden by implementing an overridden method. Also, making sure that method is declared in that interface class PlayerUiController