### PR TITLE
Hide caption fix

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/YouTubePlayer.kt
@@ -25,6 +25,7 @@ interface YouTubePlayer {
 
     fun mute()
     fun unMute()
+    fun killCC()
 
     /**
      * @param volumePercent Integer between 0 and 100

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
@@ -65,6 +65,10 @@ internal class WebViewYouTubePlayer constructor(context: Context, attrs: Attribu
     override fun unMute() {
         mainThreadHandler.post { loadUrl("javascript:unMute()") }
     }
+    
+    override fun killCC(){
+        mainThreadHandler.post{ loadUrl("javascript:killCC()")}
+    }
 
     override fun setVolume(volumePercent: Int) {
         require(!(volumePercent < 0 || volumePercent > 100)) { "Volume must be between 0 and 100" }

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -139,6 +139,10 @@
         function unMute() {
             player.unMute();
         }
+            
+        function killCC(){
+            player.unloadModule('captions');
+        }    
 
         function setVolume(volumePercent) {
             player.setVolume(volumePercent);


### PR DESCRIPTION
So, for some reason ccLoadPolicy doesnt work anymore so i found an alternative way to disable captions.
adding `player.unloadModule('captions');`  to `ayp_youtube_player.html` does the trick.

Heres a basic example that shows you how to disable captions:
```java
public class CaptionDisableExample extends AppCompatActivity {
    
    private YouTubePlayerView youTubePlayerView;

    @Override
    protected void onCreate(@Nullable Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        youTubePlayerView = findViewById(R.id.youtube_player_view);

        getLifecycle().addObserver(youTubePlayerView);
        youTubePlayerView.addYouTubePlayerListener(new AbstractYouTubePlayerListener() {
            @Override
            public void onReady(@NonNull YouTubePlayer youTubePlayer) {
                String videoId = "yS1ibDImAYU";
                youTubePlayer.loadVideo(videoId, 0);
            }

            @Override
            public void onStateChange(@NonNull YouTubePlayer youTubePlayer, @NonNull PlayerConstants.PlayerState state) {
                if (state == PlayerConstants.PlayerState.PLAYING) {
                    youTubePlayer.killCC();
                }

            }


        });

    }
}
```
