### PR TITLE
Potential fix for issue #830

### DIFF
--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -16,7 +16,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <!-- defer forces the library to execute after the html page is fully parsed. -->
         <!-- This is needed to avoid race conditions, where the library executes and calls `onYouTubeIframeAPIReady` before the page is fully parsed. -->
-        <!-- See ##873 on GitHub -->
+        <!-- See #873 on GitHub -->
         <script defer src="https://www.youtube.com/iframe_api"></script>
     </head>
 

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -21,6 +21,7 @@
     </body>
 
     <script type="text/javascript">
+        loadIFramePlayerAPI()
         
         var UNSTARTED = "UNSTARTED";
         var ENDED = "ENDED";
@@ -34,13 +35,6 @@
 
         var timerId;
 
-        // load the IFrame Player API code asynchronously.
-        var tag = document.createElement('script');
-        tag.src = "https://www.youtube.com/iframe_api";
-        var firstScriptTag = document.getElementsByTagName('script')[0];
-        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-
-        // creates an <iframe> (and YouTube player) after the API code downloads.
     	function onYouTubeIframeAPIReady() {
 
             YouTubePlayerBridge.sendYouTubeIFrameAPIReady();
@@ -62,6 +56,17 @@
     			playerVars: <<injectedPlayerVars>>
                 
     		});
+    	}
+        
+        // This function synchronously loads the IFrame API.
+        // It's done with code instead of using a <script> tag
+        // to prevent race conditions, where this custom script
+        // is loaded before the library. See #830 on GitHub
+    	function loadIFramePlayerAPI() {
+    	    var script = document.createElement('script');
+            script.async = false;
+            script.src = "https://www.youtube.com/iframe_api";
+            document.body.appendChild(script);
     	}
 
     	function sendPlayerStateChange(playerState) {

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -14,6 +14,7 @@
 
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        <script defer src="https://www.youtube.com/iframe_api"></script> <!-- defer the execution of the API code because it relies on onYouTubeIframeAPIReady being parsed. See #830 on GitHub -->
     </head>
 
     <body>
@@ -21,8 +22,6 @@
     </body>
 
     <script type="text/javascript">
-        loadIFramePlayerAPI()
-        
         var UNSTARTED = "UNSTARTED";
         var ENDED = "ENDED";
         var PLAYING = "PLAYING";
@@ -56,17 +55,6 @@
     			playerVars: <<injectedPlayerVars>>
                 
     		});
-    	}
-        
-        // This function synchronously loads the IFrame API.
-        // It's done with code instead of using a <script> tag
-        // to prevent race conditions, where this custom script
-        // is loaded before the library. See #830 on GitHub
-    	function loadIFramePlayerAPI() {
-    	    var script = document.createElement('script');
-            script.async = false;
-            script.src = "https://www.youtube.com/iframe_api";
-            document.body.appendChild(script);
     	}
 
     	function sendPlayerStateChange(playerState) {

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -14,7 +14,9 @@
 
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-        <script defer src="https://www.youtube.com/iframe_api"></script> <!-- defer the execution of the API code because it relies on onYouTubeIframeAPIReady being parsed. See #830 on GitHub -->
+        <!-- defer forces the library to execute after the html page is fully parsed. -->
+        <!-- This is needed to avoid race conditions, where the library executes and calls `onYouTubeIframeAPIReady` before the page is fully parsed. See ##873 on GitHub -->
+        <script defer src="https://www.youtube.com/iframe_api"></script>
     </head>
 
     <body>

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -14,7 +14,6 @@
 
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
 
     <body>
@@ -35,6 +34,13 @@
 
         var timerId;
 
+        // load the IFrame Player API code asynchronously.
+        var tag = document.createElement('script');
+        tag.src = "https://www.youtube.com/iframe_api";
+        var firstScriptTag = document.getElementsByTagName('script')[0];
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+        // creates an <iframe> (and YouTube player) after the API code downloads.
     	function onYouTubeIframeAPIReady() {
 
             YouTubePlayerBridge.sendYouTubeIFrameAPIReady();

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -15,7 +15,8 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <!-- defer forces the library to execute after the html page is fully parsed. -->
-        <!-- This is needed to avoid race conditions, where the library executes and calls `onYouTubeIframeAPIReady` before the page is fully parsed. See ##873 on GitHub -->
+        <!-- This is needed to avoid race conditions, where the library executes and calls `onYouTubeIframeAPIReady` before the page is fully parsed. -->
+        <!-- See ##873 on GitHub -->
         <script defer src="https://www.youtube.com/iframe_api"></script>
     </head>
 


### PR DESCRIPTION
I believe to have found a fix for https://github.com/PierfrancescoSoffritti/android-youtube-player/issues/830.

I changed the location where the IFrame Player API code is loaded to do it asynchronously (see the [doc](https://developers.google.com/youtube/iframe_api_reference#Getting_Started))
Apparently there are race conditions otherwise where it is possible that `onYouTubeIframeAPIReady` is called before the library's code is loaded properly.

Now I can neither reproduce the issue in my own project nor in the example project (the scenario that the OP showed in the first post's video which I could reproduce before).