### PR TITLE
Start Video without Audio Focus

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -17,7 +17,6 @@
             <option value="$PROJECT_DIR$/core-sample-app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A lengthier explanation to why you may want to consider using an alternative to 
 
 A list of published apps that are using this library: ([let me know](https://github.com/PierfrancescoSoffritti/android-youtube-player/issues) if you want to add your app to this list)
 
+- [Genius](https://play.google.com/store/apps/details?id=com.genius.android)
 - [reddit is fun](https://play.google.com/store/apps/details?id=com.andrewshu.android.reddit)
 - [Mobile Movie Database](https://play.google.com/store/apps/details?id=com.tmdb.themoviedatabase)
 - [dingo](https://play.google.com/store/apps/details?id=com.dingo)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ A lengthier explanation to why you may want to consider using an alternative to 
 
 A list of published apps that are using this library: ([let me know](https://github.com/PierfrancescoSoffritti/android-youtube-player/issues) if you want to add your app to this list)
 
-- [Genius](https://play.google.com/store/apps/details?id=com.genius.android)
 - [reddit is fun](https://play.google.com/store/apps/details?id=com.andrewshu.android.reddit)
 - [Mobile Movie Database](https://play.google.com/store/apps/details?id=com.tmdb.themoviedatabase)
 - [dingo](https://play.google.com/store/apps/details?id=com.dingo)

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -69,7 +69,7 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
         }
 
         /**
-         * Controls if the video is played automatically.
+         * Controls if the video is played automatically after the player is initialized.
          * @param autoplay if set to 1: the player will start automatically. If set to 0: the player will not start automatically
          */
         fun autoplay(controls: Int): Builder {
@@ -78,7 +78,7 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
         }
 
         /**
-         * Controls if the video is muted.
+         * Controls if the player will be initialized mute or not.
          * @param mute if set to 1: the player will start muted and without acquiring Audio Focus. If set to 0: the player will acquire Audio Focus
          */
         fun mute(controls: Int): Builder {

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -24,6 +24,7 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
     class Builder {
         companion object {
             private const val AUTO_PLAY = "autoplay"
+            private const val MUTE = "mute"
             private const val CONTROLS = "controls"
             private const val ENABLE_JS_API = "enablejsapi"
             private const val FS = "fs"
@@ -42,6 +43,7 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
 
         init {
             addInt(AUTO_PLAY, 0)
+            addInt(MUTE, 0)
             addInt(CONTROLS, 0)
             addInt(ENABLE_JS_API, 1)
             addInt(FS, 0)

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -69,6 +69,24 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
         }
 
         /**
+         * Controls if the video is played automatically.
+         * @param autoplay if set to 1: the player will start automatically. If set to 0: the player will not start automatically
+         */
+        fun autoplay(controls: Int): Builder {
+            addInt(AUTO_PLAY, controls)
+            return this
+        }
+
+        /**
+         * Controls if the video is muted.
+         * @param mute if set to 1: the player will start muted and without acquiring Audio Focus. If set to 0: the player will acquire Audio Focus
+         */
+        fun mute(controls: Int): Builder {
+            addInt(MUTE, controls)
+            return this
+        }
+
+        /**
          * Controls the related videos shown at the end of a video.
          * @param rel If set to 0: related videos will come from the same channel as the video that was just played. If set to 1: related videos will come from multiple channels.
          */


### PR DESCRIPTION
I have added two options to `IFramePlayerOptions `:

- `autoplay`
- `mute`

If both of these values are initialized with 1, the video will autoplay in a muted mode without gaining Audio Focus (meaning Spotify or other background playbacks will continue). As soon as the player is unmuted with the `unMute()` function, it will acquire audio focus again.
I think this should fix the issues #691 and #397 