### PR TITLE
Remove dex count

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,6 @@ buildscript {
     classpath "com.android.tools.build:gradle:$versions.gradlePlugin"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
 
-    classpath "com.getkeepsafe.dexcount:dexcount-gradle-plugin:$versions.dexCount"
-
     classpath "io.github.gradle-nexus:publish-plugin:$versions.gradleNexus"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:$versions.dokka"
   }

--- a/chromecast-sender-sample-app/build.gradle
+++ b/chromecast-sender-sample-app/build.gradle
@@ -10,6 +10,7 @@ android {
     targetSdkVersion versions.compileSdk
     versionCode versions.publishVersionCode_chromecast
     versionName versions.publishVersion_chromecast
+    multiDexEnabled true
   }
 
   buildTypes {
@@ -39,7 +40,7 @@ dependencies {
   implementation "androidx.appcompat:appcompat:$versions.appcompat"
   implementation "androidx.recyclerview:recyclerview:$versions.androidxRecyclerView"
   implementation "androidx.constraintlayout:constraintlayout:$versions.androidxConstraintLayout"
-
+  implementation "androidx.multidex:multidex:$versions.multiDex"
   implementation "androidx.mediarouter:mediarouter:$versions.androidxMediarouter"
 
   implementation "com.github.PierfrancescoSoffritti:library-sample-app-template:$versions.sampleAppTemplate"

--- a/chromecast-sender-sample-app/src/main/AndroidManifest.xml
+++ b/chromecast-sender-sample-app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:name="androidx.multidex.MultiDexApplication"
         android:theme="@style/AppTheme">
         <activity android:name="com.psoffritti.librarysampleapptemplate.core.SampleAppTemplateActivity" />
         <activity

--- a/core-sample-app/build.gradle
+++ b/core-sample-app/build.gradle
@@ -11,6 +11,7 @@ android {
     targetSdkVersion versions.compileSdk
     versionCode versions.publishVersionCode_core
     versionName versions.publishVersion_core
+    multiDexEnabled true
   }
 
   buildTypes {
@@ -50,6 +51,7 @@ dependencies {
   implementation "androidx.mediarouter:mediarouter:$versions.androidxMediarouter"
 
   implementation "com.github.PierfrancescoSoffritti:library-sample-app-template:$versions.sampleAppTemplate"
+  implementation "androidx.multidex:multidex:$versions.multiDex"
 
   debugImplementation "com.squareup.leakcanary:leakcanary-android:$versions.leakcanary"
 }

--- a/core-sample-app/build.gradle
+++ b/core-sample-app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply from: '../dependencies.gradle'
-apply plugin: 'com.getkeepsafe.dexcount'
 apply plugin: 'kotlin-android'
 
 android {

--- a/core-sample-app/src/main/AndroidManifest.xml
+++ b/core-sample-app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:name="androidx.multidex.MultiDexApplication"
         android:theme="@style/AppTheme">
         <activity
             android:name="com.pierfrancescosoffritti.androidyoutubeplayer.core.sampleapp.MainActivity"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   androidTestImplementation "androidx.test:runner:$versions.runner"
   androidTestImplementation "androidx.test.espresso:espresso-core:$versions.espressoCore"
 
-  api "androidx.lifecycle:lifecycle-runtime-ktx:$versions.androidxLifecycleRuntime"
+  implementation "androidx.lifecycle:lifecycle-runtime-ktx:$versions.androidxLifecycleRuntime"
 }
 
 ext {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,6 +26,7 @@ ext.versions = [
         androidxRecyclerView            : '1.3.0',
         androidxMediarouter             : '1.3.1',
         androidxLifecycleRuntime        : '2.6.0',
+        multiDex                        : '2.0.1',
 
         // Google Play
         googlePlayServicesCastFramework : '21.2.0',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,6 @@ ext.versions = [
 
         // Plugins
         gradlePlugin                    : '7.4.2',
-        dexCount                        : '4.0.0',
         gradleNexus                     : '1.3.0',
         dokka                           : '1.8.10',
 


### PR DESCRIPTION
https://jitpack.io/com/github/mikashboks/android-youtube-player/12.0.3/build.log

Based on log, this gradle plugin causing build compile error on jitpack.io.


```No matching variant of com.getkeepsafe.dexcount:dexcount-gradle-plugin:4.0.0 was found. The consumer was configured to find a runtime of a library compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '7.5'```