### PR TITLE
Fix changed YouTubePlayerSeekBar path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ This component is useful to display and control the time of the playback. It sho
 You can add it to your layout programmatically or in your xml.
 
 ```xml
-<com.pierfrancescosoffritti.androidyoutubeplayer.core.ui.views.YouTubePlayerSeekBar
+<com.pierfrancescosoffritti.androidyoutubeplayer.core.customui.views.YouTubePlayerSeekBar
   android:id="@+id/youtube_player_seekbar"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"


### PR DESCRIPTION
In README.md, YouTubePlayerSeekBar path in XML was wrong. Maybe its path was changed in the library, but README file was not. This PR contains this minor correction.