### PR TITLE
Add videoId to IFramePlayerOptions to avoid initialization errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,9 @@ If set to 0: web UI is not visible.
 
 If set to 1: web UI is visible.
 
+##### `videoId`
+This option indicates the initial video ID that will be played. Providing this may help avoid initialization errors reported by the API.
+
 ##### `rel`
 This option controls the related videos shown at the end of a video.
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If set to 0: web UI is not visible.
 If set to 1: web UI is visible.
 
 ##### `videoId`
-This option indicates the initial video ID that will be played. Providing this may help avoid initialization errors reported by the API.
+This option indicates the initial video ID that will be loaded. If this is not provided, the API will load a blank placeholder video initially, until `loadVideo` or `cueVideo` is called.
 
 ##### `rel`
 This option controls the related videos shown at the end of a video.

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -10,7 +10,15 @@ import org.json.JSONObject
 class IFramePlayerOptions private constructor(private val playerOptions: JSONObject) {
 
   companion object {
-    val default = Builder().controls(1).build()
+    val default = defaultBuilder().build()
+
+    fun defaultWithVideoId(videoId: String?): IFramePlayerOptions {
+      val builder = defaultBuilder()
+      videoId?.let { builder.videoId(it) }
+      return builder.build()
+    }
+
+    private fun defaultBuilder() = Builder().controls(1)
   }
 
   override fun toString(): String {

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -37,6 +37,7 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
       private const val CC_LANG_PREF = "cc_lang_pref"
       private const val LIST = "list"
       private const val LIST_TYPE = "listType"
+      private const val VIDEO_ID = "videoId"
     }
 
     private val builderOptions = JSONObject()
@@ -171,6 +172,15 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
      */
     fun fullscreen(fs: Int): Builder {
       addInt(FS, fs)
+      return this
+    }
+
+    /**
+     * Sets the initial video ID to pass when constructing the YouTube Player.
+     * Setting this value may help avoid initialization errors reported by the API.
+     */
+    fun videoId(videoId: String): Builder {
+      addString(VIDEO_ID, videoId)
       return this
     }
 

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -1,5 +1,6 @@
 package com.pierfrancescosoffritti.androidyoutubeplayer.core.player.options
 
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -184,8 +185,9 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
     }
 
     /**
-     * Sets the initial video ID to pass when constructing the YouTube Player.
-     * Setting this value may help avoid initialization errors reported by the API.
+     * Sets the initial video ID to load when constructing the YouTube Player.
+     * If this is not provided, the API will load a blank placeholder video initially,
+     * until [YouTubePlayer.loadVideo] or [YouTubePlayer.cueVideo] is called.
      */
     fun videoId(videoId: String): Builder {
       addString(VIDEO_ID, videoId)

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
@@ -90,7 +90,7 @@ class YouTubePlayerView(
       legacyTubePlayerView.initialize(
         youTubePlayerListener,
         handleNetworkEvents,
-        IFramePlayerOptions.default
+        IFramePlayerOptions.defaultWithVideoId(videoId)
       )
     }
   }


### PR DESCRIPTION
The API can report initialization errors if no `videoId` is provided initially, when constructing the `YT.Player` in JS. This error seems to happen less if using `loadVideo()` to autoplay. But when using `cueVideo()`, or doing nothing after initialization, the error happens with error value `VIDEO_NOT_PLAYABLE_IN_EMBEDDED_PLAYER`.

Passing `videoId` in IFramePlayerOptions seems to prevent the error.