### PR TITLE
Pass videoId during initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ YouTubePlayerView.initialize(YouTubePlayerListener listener, boolean handleNetwo
 ```java
 YouTubePlayerView.initialize(YouTubePlayerListener listener, boolean handleNetworkEvents, IFramePlayerOptions iframePlayerOptions)
 ```
+```java
+YouTubePlayerView.initialize(YouTubePlayerListener listener, boolean handleNetworkEvents, IFramePlayerOptions iframePlayerOptions, String videoId)
+```
 #### `initialize(YouTubePlayerListener)`
 Initialize the `YouTubePlayer`. Network events are automatically handled by the player.
 
@@ -308,6 +311,9 @@ Initialize the `YouTubePlayer`. By using the `boolean` is possible to decide if 
 By passing an `IFramePlayerOptions` to the initialize method it is possible to set some of the parameters of the IFrame YouTubePlayer. Read more about `IFramePlayerOptions` [here](#iframeplayeroptions).
 
 All the possible parameters and values are listed [here](https://developers.google.com/youtube/player_parameters#Parameters). Not all of them are supported in this library because some don't make sense in this context. [Open an issue](https://github.com/PierfrancescoSoffritti/android-youtube-player/issues) if you need a parameter that is not currently supported.
+
+#### `initialize(YouTubePlayerListener, boolean, IFramePlayerOptions, String)`
+The `videoId` can be passed as an optimization, allowing the API to load the video assets as early as possible during initialization.
 
 ### IFramePlayerOptions
 The `IFramePlayerOptions` is an optional argument that can be passed to `YouTubePlayerView.initialize(YouTubePlayerListener, boolean, IFramePlayerOptions)`, it can be used to set some of the parameters of the IFrame YouTubePlayer.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ By passing an `IFramePlayerOptions` to the initialize method it is possible to s
 All the possible parameters and values are listed [here](https://developers.google.com/youtube/player_parameters#Parameters). Not all of them are supported in this library because some don't make sense in this context. [Open an issue](https://github.com/PierfrancescoSoffritti/android-youtube-player/issues) if you need a parameter that is not currently supported.
 
 #### `initialize(YouTubePlayerListener, boolean, IFramePlayerOptions, String)`
-The `videoId` can be passed as an optimization, allowing the API to load the video assets as early as possible during initialization.
+By passing the `videoId` the video will be loaded as soon as possible after initialization.
 
 ### IFramePlayerOptions
 The `IFramePlayerOptions` is an optional argument that can be passed to `YouTubePlayerView.initialize(YouTubePlayerListener, boolean, IFramePlayerOptions)`, it can be used to set some of the parameters of the IFrame YouTubePlayer.

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
@@ -88,11 +88,13 @@ internal class LegacyYouTubePlayerView(
    * @param handleNetworkEvents if set to true a broadcast receiver will be registered and network events will be handled automatically.
    * If set to false, you should handle network events with your own broadcast receiver.
    * @param playerOptions customizable options for the embedded video player, can be null.
+   * @param videoId used to load an initial video, can be null.
    */
   fun initialize(
     youTubePlayerListener: YouTubePlayerListener,
     handleNetworkEvents: Boolean,
-    playerOptions: IFramePlayerOptions
+    playerOptions: IFramePlayerOptions,
+    videoId: String?
   ) {
     if (isYouTubePlayerReady) {
       throw IllegalStateException("This YouTubePlayerView has already been initialized.")
@@ -103,13 +105,22 @@ internal class LegacyYouTubePlayerView(
     }
 
     initialize = {
-      webViewYouTubePlayer.initialize({ it.addListener(youTubePlayerListener) }, playerOptions)
+      webViewYouTubePlayer.initialize({ it.addListener(youTubePlayerListener) }, playerOptions, videoId)
     }
 
     if (!handleNetworkEvents) {
       initialize()
     }
   }
+
+  /**
+   * Initialize the player.
+   * @param playerOptions customizable options for the embedded video player.
+   *
+   * @see LegacyYouTubePlayerView.initialize
+   */
+  fun initialize(youTubePlayerListener: YouTubePlayerListener, handleNetworkEvents: Boolean, playerOptions: IFramePlayerOptions) =
+    initialize(youTubePlayerListener, handleNetworkEvents, playerOptions, null)
 
   /**
    * Initialize the player.

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
@@ -88,7 +88,7 @@ internal class LegacyYouTubePlayerView(
    * @param handleNetworkEvents if set to true a broadcast receiver will be registered and network events will be handled automatically.
    * If set to false, you should handle network events with your own broadcast receiver.
    * @param playerOptions customizable options for the embedded video player, can be null.
-   * @param videoId used to load an initial video, can be null.
+   * @param videoId optional, used to load a video right after initialization.
    */
   fun initialize(
     youTubePlayerListener: YouTubePlayerListener,

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/WebViewYouTubePlayer.kt
@@ -93,9 +93,9 @@ internal class WebViewYouTubePlayer constructor(
 
   internal var isBackgroundPlaybackEnabled = false
 
-  internal fun initialize(initListener: (YouTubePlayer) -> Unit, playerOptions: IFramePlayerOptions?) {
+  internal fun initialize(initListener: (YouTubePlayer) -> Unit, playerOptions: IFramePlayerOptions?, videoId: String?) {
     youTubePlayerInitListener = initListener
-    initWebView(playerOptions ?: IFramePlayerOptions.default)
+    initWebView(playerOptions ?: IFramePlayerOptions.default, videoId)
   }
 
   // create new set to avoid concurrent modifications
@@ -111,7 +111,7 @@ internal class WebViewYouTubePlayer constructor(
   }
 
   @SuppressLint("SetJavaScriptEnabled")
-  private fun initWebView(playerOptions: IFramePlayerOptions) {
+  private fun initWebView(playerOptions: IFramePlayerOptions, videoId: String?) {
     settings.apply {
       javaScriptEnabled = true
       mediaPlaybackRequiresUserGesture = false
@@ -121,6 +121,7 @@ internal class WebViewYouTubePlayer constructor(
     addJavascriptInterface(YouTubePlayerBridge(this), "YouTubePlayerBridge")
 
     val htmlPage = readHTMLFromUTF8File(resources.openRawResource(R.raw.ayp_youtube_player))
+      .replace("<<injectedVideoId>>", if (videoId != null) { "'$videoId'" } else { "undefined" })
       .replace("<<injectedPlayerVars>>", playerOptions.toString())
 
     loadDataWithBaseURL(playerOptions.getOrigin(), htmlPage, "text/html", "utf-8", null)

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
@@ -90,8 +90,26 @@ class YouTubePlayerView(
       legacyTubePlayerView.initialize(
         youTubePlayerListener,
         handleNetworkEvents,
-        IFramePlayerOptions.default
+        IFramePlayerOptions.default,
+        videoId
       )
+    }
+  }
+
+  /**
+   * Initialize the player. You must call this method before using the player.
+   * @param youTubePlayerListener listener for player events
+   * @param handleNetworkEvents if set to true a broadcast receiver will be registered and network events will be handled automatically.
+   * If set to false, you should handle network events with your own broadcast receiver.
+   * @param playerOptions customizable options for the embedded video player.
+   * @param videoId optionally used to load an initial video.
+   */
+  fun initialize(youTubePlayerListener: YouTubePlayerListener, handleNetworkEvents: Boolean, playerOptions: IFramePlayerOptions, videoId: String?) {
+    if (enableAutomaticInitialization) {
+      throw IllegalStateException(AUTO_INIT_ERROR)
+    }
+    else {
+      legacyTubePlayerView.initialize(youTubePlayerListener, handleNetworkEvents, playerOptions, videoId)
     }
   }
 

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
@@ -102,30 +102,14 @@ class YouTubePlayerView(
    * @param handleNetworkEvents if set to true a broadcast receiver will be registered and network events will be handled automatically.
    * If set to false, you should handle network events with your own broadcast receiver.
    * @param playerOptions customizable options for the embedded video player.
-   * @param videoId optionally used to load an initial video.
+   * @param videoId optional, used to load an initial video.
    */
-  fun initialize(youTubePlayerListener: YouTubePlayerListener, handleNetworkEvents: Boolean, playerOptions: IFramePlayerOptions, videoId: String?) {
+  fun initialize(youTubePlayerListener: YouTubePlayerListener, handleNetworkEvents: Boolean, playerOptions: IFramePlayerOptions, videoId: String? = null) {
     if (enableAutomaticInitialization) {
       throw IllegalStateException(AUTO_INIT_ERROR)
     }
     else {
       legacyTubePlayerView.initialize(youTubePlayerListener, handleNetworkEvents, playerOptions, videoId)
-    }
-  }
-
-  /**
-   * Initialize the player. You must call this method before using the player.
-   * @param youTubePlayerListener listener for player events
-   * @param handleNetworkEvents if set to true a broadcast receiver will be registered and network events will be handled automatically.
-   * If set to false, you should handle network events with your own broadcast receiver.
-   * @param playerOptions customizable options for the embedded video player.
-   */
-  fun initialize(youTubePlayerListener: YouTubePlayerListener, handleNetworkEvents: Boolean, playerOptions: IFramePlayerOptions) {
-    if (enableAutomaticInitialization) {
-      throw IllegalStateException(AUTO_INIT_ERROR)
-    }
-    else {
-      legacyTubePlayerView.initialize(youTubePlayerListener, handleNetworkEvents, playerOptions)
     }
   }
 

--- a/core/src/main/res/raw/ayp_youtube_player.html
+++ b/core/src/main/res/raw/ayp_youtube_player.html
@@ -45,6 +45,7 @@
     			
         height: '100%',
     	  width: '100%',
+    	  videoId: <<injectedVideoId>>,
     			
         events: {
     	    onReady: function(event) { YouTubePlayerBridge.sendReady() },


### PR DESCRIPTION
Copy of #1167 but targeting `dev` branch.

This is an optional optimization to allow the API to load the video assets as soon as possible after initialization.