### PR TITLE
Set MaxMetaspaceSize to 512m to fix Dokka Gradle build step

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Without this configuration, the `:core:dokkaJavadoc` Gradle build step was failing/hanging with error:

```
Exception in thread "DefaultDispatcher-worker-7" java.lang.OutOfMemoryError: Metaspace
The Daemon will expire after the build after running out of JVM Metaspace.
The project memory settings are likely not configured or are configured to an insufficient value.
The daemon will restart for the next build, which may increase subsequent build times.
These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'.
The currently configured max heap space is '512 MiB' and the configured max metaspace is '256 MiB'.
For more information on how to set these values, visit the user guide at https://docs.gradle.org/8.0/userguide/build_environment.html#configuring_jvm_memory
To disable this warning, set 'org.gradle.daemon.performance.disable-logging=true'.
Daemon will be stopped at the end of the build after running out of JVM Metaspace
```

For whatever reason the build worked on `master` but not current `dev` branch.

Specifically I was running `$ ./gradlew :core:publishToMavenLocal`