### PR TITLE
IFramePlayerOptions: Add "start", deprecate "modestBranding"

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ If set to 0: the player will show captions.
 
 If set to 1: the player won't show captions.
 
+##### `start`
+This parameter causes the player to begin playing the video at the given number of seconds from the start of the video. The parameter value is a positive integer.
+
+It works similarly to the `seekTo` method, and the `startSeconds` argument of `loadVideo` and `cueVideo`.
+
+##### `end`
+This parameter specifies the time, measured in seconds from the beginning of the video, when the player should stop playing the video. The parameter value is a positive integer.
+
 ### Full screen
 The full screen button can be added to the player by using `IFramePlayerOptions`
 

--- a/chromecast-receiver/js/YouTubePlayer.js
+++ b/chromecast-receiver/js/YouTubePlayer.js
@@ -38,7 +38,6 @@ function YouTubePlayer(communicationConstants, communicationChannel) {
                 fs: 0,
                 origin: 'https://www.youtube.com',
                 rel: 0,
-                showinfo: 0,
                 iv_load_policy: 3
             }            
         })

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -32,7 +32,6 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
       private const val REL = "rel"
       private const val SHOW_INFO = "showinfo"
       private const val IV_LOAD_POLICY = "iv_load_policy"
-      private const val MODEST_BRANDING = "modestbranding"
       private const val CC_LOAD_POLICY = "cc_load_policy"
       private const val CC_LANG_PREF = "cc_lang_pref"
       private const val LIST = "list"
@@ -51,7 +50,6 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
       addInt(REL, 0)
       addInt(SHOW_INFO, 0)
       addInt(IV_LOAD_POLICY, 3)
-      addInt(MODEST_BRANDING, 1)
       addInt(CC_LOAD_POLICY, 0)
     }
 
@@ -175,12 +173,12 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
     }
 
     /**
-     * Controls if the YouTube logo will be displayed in the control bar or not.
-     * @param modestBranding If set to 1: the YouTube logo will not be displayed in the control bar.
-     * If set to 0: the YouTube logo will be displayed in the control bar.
+     * The modestbranding parameter is deprecated and will have no effect.
+     * To align with YouTube's branding requirements, the player now determines the appropriate branding treatment based on a combination of factors, including player size, other API parameters (e.g. controls), and additional signals.
+     * See August 15, 2023 deprecation announcement: https://developers.google.com/youtube/player_parameters#release_notes_08_15_2023
      */
+    @Deprecated("Deprecated and will have no effect")
     fun modestBranding(modestBranding: Int): Builder {
-      addInt(MODEST_BRANDING, modestBranding)
       return this
     }
 

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -36,6 +36,7 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
       private const val LIST = "list"
       private const val LIST_TYPE = "listType"
       private const val START = "start"
+      private const val END = "end"
     }
 
     private val builderOptions = JSONObject()
@@ -178,6 +179,16 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
      */
     fun start(startSeconds: Int): Builder {
       addInt(START, startSeconds)
+      return this
+    }
+
+    /**
+     * This parameter specifies the time, measured in seconds from the beginning of the video, when the player should stop playing the video.
+     * The parameter value is a positive integer.
+     * @param endSeconds positive integer specifying the time, measured in seconds from the beginning of the video, when the player should stop playing the video.
+     */
+    fun end(endSeconds: Int): Builder {
+      addInt(END, endSeconds)
       return this
     }
 

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -30,7 +30,6 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
       private const val FS = "fs"
       internal const val ORIGIN = "origin"
       private const val REL = "rel"
-      private const val SHOW_INFO = "showinfo"
       private const val IV_LOAD_POLICY = "iv_load_policy"
       private const val CC_LOAD_POLICY = "cc_load_policy"
       private const val CC_LANG_PREF = "cc_lang_pref"
@@ -49,7 +48,6 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
       addInt(FS, 0)
       addString(ORIGIN, "https://www.youtube.com")
       addInt(REL, 0)
-      addInt(SHOW_INFO, 0)
       addInt(IV_LOAD_POLICY, 3)
       addInt(CC_LOAD_POLICY, 0)
     }

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/options/IFramePlayerOptions.kt
@@ -36,6 +36,7 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
       private const val CC_LANG_PREF = "cc_lang_pref"
       private const val LIST = "list"
       private const val LIST_TYPE = "listType"
+      private const val START = "start"
     }
 
     private val builderOptions = JSONObject()
@@ -169,6 +170,16 @@ class IFramePlayerOptions private constructor(private val playerOptions: JSONObj
      */
     fun fullscreen(fs: Int): Builder {
       addInt(FS, fs)
+      return this
+    }
+
+    /**
+     * This parameter causes the player to begin playing the video at the given number of seconds from the start of the video.
+     * The parameter value is a positive integer.
+     * @param startSeconds positive integer, number of seconds to offset playback from the start of the video.
+     */
+    fun start(startSeconds: Int): Builder {
+      addInt(START, startSeconds)
       return this
     }
 


### PR DESCRIPTION
Add `start` to specify initial offset in seconds, similar to `seekTo`, and similar to the argument in `loadVideo` and `cueVideo`, but without having to call those methods.

Deprecate `modestBranding` — see deprecation announcement https://developers.google.com/youtube/player_parameters#release_notes_08_15_2023