### PR TITLE
Expose software/hardware layer toggle on YouTubePlayerView

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,8 @@ If you need to disable hardware acceleration in your application, you can enable
 
 Disabling hardware acceleration on the Activity containing `YouTubePlayerView` may result in some weird behavior. The one I have observed so far shows a black image in the player, while the audio is playing normally.
 
+On a small number of devices (notably some low-end Android 11 media boards whose AAudio low-latency path is incomplete) the hardware accelerated WebView pipeline tears down the audio output stream during playback, producing continuous video/audio cutting. As a per-view workaround you can switch the embedded WebView to a software-rendered layer without touching the rest of the Activity by calling `YouTubePlayerView.setWebViewSoftwareLayerType()`. Use `YouTubePlayerView.setWebViewHardwareLayerType()` to revert.
+
 ### Play YouTube videos in the background
 With this library it's easy to play YouTube videos when the app is not visible. In order to do that you simply have to not call `youTubePlayer.pause()` when the Activity is being paused or stopped and enable background playback by calling `YouTubePlayerView.enableBackgroundPlayback(true)`.
 

--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/YouTubePlayerView.kt
@@ -247,4 +247,30 @@ class YouTubePlayerView(
       height = targetHeight
     }
   }
+
+  /**
+   * Switch the embedded WebView to a software-rendered layer
+   * ([View.LAYER_TYPE_SOFTWARE]). This bypasses the GPU compositor for the
+   * player only and is the documented Android workaround for video and
+   * audio playback glitches caused by the WebView / GPU pipeline on some
+   * devices, notably a number of low-end Android 11 boards whose AAudio
+   * low-latency path is incomplete (see issues #1115 and #1121). Unlike
+   * disabling hardware acceleration on the whole Activity, this hook
+   * keeps the rest of the UI hardware accelerated.
+   *
+   * Call this once after the view has been added to the hierarchy, for
+   * example guarded by [android.os.Build.MODEL].
+   */
+  fun setWebViewSoftwareLayerType() {
+    legacyTubePlayerView.webViewYouTubePlayer.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+  }
+
+  /**
+   * Restore the default hardware-accelerated layer
+   * ([View.LAYER_TYPE_HARDWARE]) on the embedded WebView. Counterpart of
+   * [setWebViewSoftwareLayerType].
+   */
+  fun setWebViewHardwareLayerType() {
+    legacyTubePlayerView.webViewYouTubePlayer.setLayerType(View.LAYER_TYPE_HARDWARE, null)
+  }
 }


### PR DESCRIPTION
### Issue

Closes #1121.

The reporter sees continuous video and audio cutting on a giada DN74 (Android
11) tablet while the same code runs fine on the Android 11 emulator and on a
Realme 5 Pro. The logcat is dominated by:

```
AudioStreamBuilder build() MMAP not used because AAUDIO_PERFORMANCE_MODE_LOW_LATENCY not requested.
AudioStreamLegacy  onAudioDeviceUpdate() request DISCONNECT in data callback, device 9 => 0
AudioStreamLegacy  processCallbackCommon() data, stream disconnected
AudioTrack         processAudioBuffer(976): EVENT_MORE_DATA requested 4488 bytes but callback returned -1 bytes
```

That sequence is the documented Android 11 WebView / GPU-driver interaction
where a frame produced through the hardware accelerated WebView pipeline
tears down the AAudio output stream on devices whose low-latency audio path
is incomplete (a number of low-end Rockchip / MTK media boxes are affected,
including the giada DN74). Issue #1115 reports the same `AAUDIO_PERFORMANCE_MODE_LOW_LATENCY`
log signature.

### Why a library change

The Android-recommended workaround is `View.setLayerType(LAYER_TYPE_SOFTWARE, null)`
on the offending WebView, which bypasses the GPU compositor for that view
and keeps audio playback stable. The wider workaround "disable hardware
acceleration on the whole Activity" is already mentioned in the README under
**Useful info > Hardware acceleration**, but it has the well-known side
effect of producing a black image while audio plays normally, so it is not a
real fix.

The targeted, per-view workaround was unreachable from application code
because `WebViewYouTubePlayer` is `internal`. This PR exposes it.

### Change

`YouTubePlayerView` gains two opt-in methods that delegate to
`View.setLayerType` on the embedded WebView:

```kotlin
fun setWebViewSoftwareLayerType()
fun setWebViewHardwareLayerType()
```

Typical usage:

```kotlin
val youTubePlayerView: YouTubePlayerView = findViewById(R.id.youtube_player_view)
if (Build.MODEL.equals("DN74", ignoreCase = true)) {
    youTubePlayerView.setWebViewSoftwareLayerType()
}
```

The README "Hardware acceleration" section is updated with a short note that
links the new hook to playback glitches on Android 11 devices with broken
AAudio paths.

### Compatibility

* Purely additive API. No existing public symbol is modified or removed.
* Default behaviour (hardware-accelerated layer) is unchanged.
* The new methods just forward to the standard Android `View.setLayerType`
  API, so they cannot regress existing tests or sample apps.

Marking this as a draft so you can decide whether you would prefer the
methods to live on `LegacyYouTubePlayerView` only or be exposed as an XML
attribute as well.
