### PR TITLE
docs: fix README parameter typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1288,9 +1288,9 @@ function hideCaption() {
 
 This workaround gets the id from 'more videos' and plays it as a next video, you can think of it like the "recomended" section on YouTube. You can use it like auto-play on YouTube.
 
-If the `rel` paramter is set to 0: the next video will come from the same channel as the video that was just played.
+If the `rel` parameter is set to 0: the next video will come from the same channel as the video that was just played.
 
-If the `rel` paramater is set to 1: the next video will be from related videos that come from multiple channels.
+If the `rel` parameter is set to 1: the next video will be from related videos that come from multiple channels.
 
 Add this to `ayp_youtube_player.html`, and call it inside `onReady`.
 


### PR DESCRIPTION
## Summary
- fix two spelling typos in the README's `rel` parameter description
- leave the surrounding IFramePlayerOptions docs unchanged

## Validation
- confirmed `paramter` and `paramater` were present only in `README.md` on `dev`
- checked the before/after diff in memory
- ran `git diff --no-index --check` on the in-memory diff (no whitespace warnings)